### PR TITLE
Added **kwargs to Collection.find method in order to allow MongoEngine t...

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -455,7 +455,7 @@ class Collection(object):
             "err": None,
         }
 
-    def count(self):
+    def count(self, with_limit_and_skip = False):
         return len(self._documents)
 
     def drop(self):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -253,7 +253,7 @@ class Collection(object):
         # TODO: this looks a little too naive...
         return dict((k, v) for k, v in iteritems(doc) if not k.startswith("$"))
 
-    def find(self, spec = None, fields = None, filter = None, sort = None, timeout = True, limit = 0, snapshot = False, as_class = None, skip = 0):
+    def find(self, spec = None, fields = None, filter = None, sort = None, timeout = True, limit = 0, snapshot = False, as_class = None, skip = 0, **kwargs):
         if filter is not None:
             _print_deprecation_warning('filter', 'spec')
             if spec is None:

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -589,7 +589,7 @@ class Cursor(object):
         else:
             self._dataset = iter(sorted(self._dataset, key = lambda x:resolve_key_value(key_or_list, x), reverse = direction < 0))
         return self
-    def count(self):
+    def count(self, with_limit_and_skip = False):
         arr = [x for x in self._dataset]
         count = len(arr)
         self._dataset = iter(arr)


### PR DESCRIPTION
Added **kwargs to Collection.find method in order to allow MongoEngine to use MongoMock instead of PyMongo.

This change don't break anything, but allows MongoEngine to use MongoMock instead of PyMongo (MongoEngine also requires minor changes that I'm also pull requesting to their repository).

I've added **kwargs as a "general" solution, but the problem I was trying to solve was the need of the parameter slaves_okay .

I'm open to any suggestion to achieve the same result if this change don't seems to you OK.

Thanks for your attention :) .