### PR TITLE
Added start_request for MongoClient & Use kwargs for support all find options

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -273,7 +273,7 @@ class Collection(object):
         # TODO: this looks a little too naive...
         return dict((k, v) for k, v in iteritems(doc) if not k.startswith("$"))
 
-    def find(self, spec = None, fields = None, filter = None, sort = None, timeout = True, limit = 0, snapshot = False, as_class = None, skip = 0, slave_okay=False):
+    def find(self, spec=None, fields=None, filter=None, sort=None,  limit=0, as_class=None, skip=0, **kwargs):
         if filter is not None:
             _print_deprecation_warning('filter', 'spec')
             if spec is None:

--- a/mongomock/connection.py
+++ b/mongomock/connection.py
@@ -53,7 +53,21 @@ class Connection(object):
         return list(self._databases.keys())
 
 
+class FakeRequest(object):
+    def end(self):
+        self.connection.end_request()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
 #Connection is now depricated, it's called MongoClient instead
 class MongoClient(Connection):
     def stub(self):
         pass
+
+    def start_request(self):
+        return FakeRequest()

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6,7 +6,7 @@ from .utils import TestCase
 class CollectionAPITest(TestCase):
     def setUp(self):
         super(CollectionAPITest, self).setUp()
-        self.conn = mongomock.Connection()
+        self.conn = mongomock.MongoClient()
         self.db = self.conn['somedb']
 
     def test__get_subcollections(self):
@@ -128,8 +128,10 @@ class CollectionAPITest(TestCase):
         self.assertNotIsInstance(collection.find(), list)
         self.assertNotIsInstance(collection.find(), tuple)
 
-    def test__find_slave_okay(self):
+    def test__find_with_special_options(self):
         self.db.collection.find({}, slave_okay=True)
+        self.db.collection.find({}, read_preference=3, secondary_acceptable_latency_ms=15)
+        self.db.collection.find({}, snapshot=True)
 
     def test__find_and_modify_cannot_remove_and_new(self):
         with self.assertRaises(mongomock.OperationFailure):
@@ -198,3 +200,11 @@ class CollectionAPITest(TestCase):
         self.db['users'].insert([u1, u2])
         self.assertEquals(self.db['users'].find(sort=[("name", 1)], skip=1).count(), 1)
         self.assertEquals(self.db['users'].find(sort=[("name", 1)], skip=1)[0]['name'], 'second')
+
+    def test__start_request(self):
+        with self.conn.start_request():
+            self.db.collection.insert({'a': 1})
+            self.db.collection.update({'a': 1}, {'$set': {'b': 2}})
+            doc = self.db.collection.find_one({'a': 1})
+            self.assertEqual(doc['a'], 1)
+            self.assertEqual(doc['b'], 2)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -479,7 +479,7 @@ class _CollectionTest(_CollectionComparisonTest):
 
     def test__set_upsert(self):
         self.cmp.do.remove()
-        self.cmp.do.update({"name": "bob"}, {"$set": {}}, True)
+        self.cmp.do.update({"name": "bob"}, {"$set": {"age": 2}}, True)
         self.cmp.compare.find()
         self.cmp.do.update({"name": "alice"}, {"$set": {"age": 1}}, True)
         self.cmp.compare_ignore_order.find()


### PR DESCRIPTION
For support [start_request](http://api.mongodb.org/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient.start_request) and [all find options](http://api.mongodb.org/python/current/api/pymongo/collection.html#pymongo.collection.Collection.find)