### PR TITLE
Add support for _id as dict().

### DIFF
--- a/mongomock/__version__.py
+++ b/mongomock/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0"
+__version__ = "2.0.0-post2-cb"

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -255,11 +255,9 @@ class Collection(object):
                             existing_document['_id'] = _id
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
-                            # id changed, fix index
-                            if type(_id) == dict:
-                                _id = hashdict(_id)
-                            del self._documents[_id]
-                            self.insert(existing_document)
+                            raise OperationFailure(
+                                "The _id field cannot be changed from {0} to {1}".format(
+                                    existing_document['_id'], _id))
                         break
                     else:
                         # can't mix modifiers with non-modifiers in update

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -8,7 +8,7 @@ import warnings
 from sentinels import NOTHING
 from .filtering import filter_applies, iter_key_candidates
 from . import ObjectId, OperationFailure, DuplicateKeyError
-from .helpers import basestring, xrange, print_deprecation_warning
+from .helpers import basestring, xrange, print_deprecation_warning, hashdict
 
 try:
     from collections import OrderedDict
@@ -67,6 +67,8 @@ class Collection(object):
         if '_id' not in data:
             data['_id'] = ObjectId()
         object_id = data['_id']
+        if type(object_id) == dict:
+            object_id = hashdict(object_id)
         if object_id in self._documents:
             raise DuplicateKeyError("Duplicate Key Error", 11000)
         for unique in self._uniques:
@@ -79,7 +81,7 @@ class Collection(object):
                 raise DuplicateKeyError("Duplicate Key Error", 11000)
 
         self._documents[object_id] = self._internalize_dict(data)
-        return object_id
+        return data['_id']
 
     def _internalize_dict(self, d):
         return dict((k, copy.deepcopy(v)) for k, v in iteritems(d))
@@ -128,7 +130,7 @@ class Collection(object):
                         # we use _set_updater
                         subdocument = self._update_document_fields_positional(existing_document,v, spec, _set_updater, subdocument)
                     else:
-                        self._update_document_fields(existing_document, v, _set_updater)                 
+                        self._update_document_fields(existing_document, v, _set_updater)
 
                 elif k == '$unset':
                     for field, value in iteritems(v):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -256,6 +256,8 @@ class Collection(object):
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
                             # id changed, fix index
+                            if type(_id) == dict:
+                                _id = hashdict(_id)
                             del self._documents[_id]
                             self.insert(existing_document)
                         break
@@ -518,6 +520,8 @@ class Collection(object):
         to_delete = list(self.find(spec = spec_or_id))
         for doc in to_delete:
             doc_id = doc['_id']
+            if type(doc_id) == dict:
+                doc_id = hashdict(doc_id)
             del self._documents[doc_id]
 
         return {

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -48,7 +48,74 @@ def _index_list(key_or_list, direction=None):
                             "key_or_list must be an instance of list")
     return key_or_list
 
-  
+
+class hashdict(dict):
+    """
+    hashable dict implementation, suitable for use as a key into
+    other dicts.
+
+    >>> h1 = hashdict({"apples": 1, "bananas":2})
+    >>> h2 = hashdict({"bananas": 3, "mangoes": 5})
+    >>> h1+h2
+    hashdict(apples=1, bananas=3, mangoes=5)
+    >>> d1 = {}
+    >>> d1[h1] = "salad"
+    >>> d1[h1]
+    'salad'
+    >>> d1[h2]
+    Traceback (most recent call last):
+    ...
+    KeyError: hashdict(bananas=3, mangoes=5)
+
+    based on answers from
+    http://stackoverflow.com/questions/1151658/python-hashable-dicts
+
+    """
+    def __key(self):
+        return tuple(sorted(self.items()))
+
+    def __repr__(self):
+        return "{0}({1})".format(
+            self.__class__.__name__,
+            ", ".join("{0}={1}".format(str(i[0]), repr(i[1])) for i in self.__key()))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __setitem__(self, key, value):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def __delitem__(self, key):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def clear(self):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def pop(self, *args, **kwargs):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def popitem(self, *args, **kwargs):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def setdefault(self, *args, **kwargs):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def update(self, *args, **kwargs):
+        raise TypeError("{0} does not support item assignment"
+                        .format(self.__class__.__name__))
+
+    def __add__(self, right):
+        result = hashdict(self)
+        dict.update(result, right)
+        return result
+
+
 def _fields_list_to_dict(fields):
     """Takes a list of field names and returns a matching dictionary.
 

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -49,6 +49,20 @@ def _index_list(key_or_list, direction=None):
     return key_or_list
 
 
+def _gen_deep_hashdict(tup):
+    """
+    Recursively replace dicts in a tuple with hashdicts
+    """
+    first = tup[0]
+    rest = tup[1:]
+    if type(first) == dict:
+        first = hashdict(first)
+    if rest:
+        return tuple([first, _gen_deep_hashdict(rest)])
+    else:
+        return first
+
+
 class hashdict(dict):
     """
     hashable dict implementation, suitable for use as a key into
@@ -72,7 +86,7 @@ class hashdict(dict):
 
     """
     def __key(self):
-        return tuple(sorted(self.items()))
+        return frozenset(_gen_deep_hashdict(item) for item in self.items())
 
     def __repr__(self):
         return "{0}({1})".format(

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import warnings
+from six import (iteritems)
 
 
 def print_deprecation_warning(old_param_name, new_param_name):
@@ -73,7 +74,7 @@ class hashdict(dict):
     """
     def __key(self):
         return frozenset((k, hashdict(v) if type(v) == dict else v)
-                         for k, v in self.iteritems())
+                         for k, v in iteritems(self))
 
     def __repr__(self):
         return "{0}({1})".format(

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -73,7 +73,10 @@ class hashdict(dict):
 
     """
     def __key(self):
-        return frozenset((k, hashdict(v) if type(v) == dict else v)
+        return frozenset((k,
+                          hashdict(v) if type(v) == dict else
+                          tuple(v) if type(v) == list else
+                          v)
                          for k, v in iteritems(self))
 
     def __repr__(self):

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -49,20 +49,6 @@ def _index_list(key_or_list, direction=None):
     return key_or_list
 
 
-def _gen_deep_hashdict(tup):
-    """
-    Recursively replace dicts in a tuple with hashdicts
-    """
-    first = tup[0]
-    rest = tup[1:]
-    if type(first) == dict:
-        first = hashdict(first)
-    if rest:
-        return tuple([first, _gen_deep_hashdict(rest)])
-    else:
-        return first
-
-
 class hashdict(dict):
     """
     hashable dict implementation, suitable for use as a key into
@@ -86,7 +72,8 @@ class hashdict(dict):
 
     """
     def __key(self):
-        return frozenset(_gen_deep_hashdict(item) for item in self.items())
+        return frozenset((k, hashdict(v) if type(v) == dict else v)
+                         for k, v in self.iteritems())
 
     def __repr__(self):
         return "{0}({1})".format(

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -93,7 +93,7 @@ class CollectionAPITest(TestCase):
     def test__distinct_array_field(self):
         self.db.collection.insert([{'f1': ['v1', 'v2', 'v1']}, {'f1': ['v2', 'v3']}])
         cursor = self.db.collection.find()
-        self.assertEquals(set(cursor.distinct('f1')), set(['v1', 'v2', 'v3']))		
+        self.assertEquals(set(cursor.distinct('f1')), set(['v1', 'v2', 'v3']))
 
     def test__cursor_clone(self):
         self.db.collection.insert([{"a": "b"}, {"b": "c"}, {"c": "d"}])
@@ -197,6 +197,11 @@ class CollectionAPITest(TestCase):
         d["a"] = "b"
         l.append(1)
         self.assertEquals(list(self.db.collection.find()), [{"_id": obj_id, "d": {}, "l": []}])
+
+    def test__update_cannot_change__id(self):
+        self.db.collection.insert({'_id': 1, 'a': 1})
+        with self.assertRaises(mongomock.OperationFailure):
+            self.db.collection.update({'_id': 1}, {'_id': 2, 'b': 2})
 
     def test__string_matching(self):
         """

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+from mongomock.helpers import hashdict
+
+
+class HashdictTest(TestCase):
+    def test__hashdict(self):
+        """ Make sure hashdict can be used as a key for a dict """
+        h = {}
+        _id = hashdict({'a': 1})
+        h[_id] = 'foo'
+        self.assertEqual(h[_id], 'foo')
+        _id = hashdict({'a': {'foo': 2}})
+        h[_id] = 'foo'
+        self.assertEqual(h[_id], 'foo')
+        _id = hashdict({'a': {'foo': {'bar': 3}}})
+        h[_id] = 'foo'
+        self.assertEqual(h[_id], 'foo')
+        _id = hashdict({hashdict({'a': '3'}): {'foo': 2}})
+        h[_id] = 'foo'
+        self.assertEqual(h[_id], 'foo')

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -5,7 +5,7 @@ import re
 import platform
 import sys
 
-from .utils import TestCase, skipIf, DBRef, expectedFailure
+from .utils import TestCase, skipIf, DBRef
 
 import mongomock
 from mongomock import Database
@@ -545,7 +545,6 @@ class _CollectionTest(_CollectionComparisonTest):
         self.cmp.do.update({'name': 'bob'}, {'$unset': {'a': False}})
         self.cmp.compare.find({'name' : 'bob'})
 
-    @expectedFailure
     def test__set_upsert(self):
         self.cmp.do.remove()
         self.cmp.do.update({"name": "bob"}, {"$set": {}}, True)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -179,23 +179,6 @@ class _CollectionTest(_CollectionComparisonTest):
         self.cmp.do.save({"_id":ObjectId(), "someProp":1}, safe=True)
         self.cmp.compare_ignore_order.find()
 
-    def test__update_object_id_as_dict(self):
-        if isinstance(self, _MongoClientMixin):
-            self.skipTest("MongoClient does not allow changing _id on existing docs")
-        self.cmp.do.remove()
-
-        # update with top-level dictionary
-        doc_ids = [
-            {'A': 1},
-            {'A': [1, 2, 3]},
-            {'A': {'sub': {'subsub': 3}}}
-        ]
-        for doc_id in doc_ids:
-            _id = self.cmp.do.insert({'_id': doc_id, 'a': 1})
-            _id = self.cmp.do.update({'_id': doc_id}, {'_id': 1, 'b': 2})
-
-            self.cmp.do.remove({'_id': 1})
-
     def test__insert_object_id_as_dict(self):
         self.cmp.do.remove()
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -189,6 +189,7 @@ class _CollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find({'id': {'A': 1}})
         self.cmp.compare.find({'id': _id['fake']})
         self.cmp.compare.find({'id': _id['real']})
+        self.cmp.do.insert({'_id': {'A': {'sub': {'subsub': 3}}}, 'a': 1})
 
     def test__count(self):
         self.cmp.compare.count()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (2, 7):
-    from unittest2 import TestCase, skipIf, expectedFailure
+    from unittest2 import TestCase, skipIf
 else:
-    from unittest import TestCase, skipIf, expectedFailure
+    from unittest import TestCase, skipIf
 
 
 class DBRef(object):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (2, 7):
-    from unittest2 import TestCase, skipIf
+    from unittest2 import TestCase, skipIf, expectedFailure
 else:
-    from unittest import TestCase, skipIf
+    from unittest import TestCase, skipIf, expectedFailure
 
 
 class DBRef(object):


### PR DESCRIPTION
Currently, collection throws an 'unhashable' exception in _insert trying
to us data['id]' as a key to the doc dictionary.  Pymongo allows _id to be a
dict().