### PR TITLE
Allow subdocument replacement with $set operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ pip-log.txt
 flycheck-*
 .DS_Store
 .env
+
+### vim
+.ropeproject/

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -328,6 +328,30 @@ class CollectionAPITest(TestCase):
         expected_document["list_field"][2]["marker"] = True
         self.assertEquals(list(self.db.collection.find()), [expected_document])
 
+    def test__set_replace_subdocument(self):
+        base_document = {
+            "int_field": 1,
+            "list_field": [
+                {"str_field": "a"},
+                {"str_field": "b", "int_field": 1},
+                {"str_field": "c"}
+            ]}
+        new_subdoc = {"str_field": "x"}
+        self.db.collection.insert(base_document)
+        self.db.collection.update(
+            {"int_field": 1},
+            {"$set": {"list_field.1": new_subdoc}})
+
+        self.db.collection.update(
+            {"int_field": 1, "list_field.2.str_field": "c"},
+            {"$set": {"list_field.2": new_subdoc}})
+
+        expected_document = copy.deepcopy(base_document)
+        expected_document["list_field"][1] = new_subdoc
+        expected_document["list_field"][2] = new_subdoc
+
+        self.assertEquals(list(self.db.collection.find()), [expected_document])
+
     @skipIf(not _HAVE_PYMONGO,"pymongo not installed")
     def test__find_and_modify_with_sort(self):
         self.db.collection.insert({"time_check": float(time.time())})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -563,7 +563,7 @@ class _CollectionTest(_CollectionComparisonTest):
 
     def test__set_upsert(self):
         self.cmp.do.remove()
-        self.cmp.do.update({"name": "bob"}, {"$set": {}}, True)
+        self.cmp.do.update({"name": "bob"}, {"$set": {"age": 1}}, True)
         self.cmp.compare.find()
         self.cmp.do.update({"name": "alice"}, {"$set": {"age": 1}}, True)
         self.cmp.compare_ignore_order.find()


### PR DESCRIPTION
* With {"$set": {"subdocs.2": {...}}} you can replace the third sub-
  document referenced by "subdocs"