### PR TITLE
Adaptations to actual pymongo signatures

### DIFF
--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -27,9 +27,10 @@ except:
 from mongomock.__version__ import __version__
 
 
-__all__ = ['Connection', 'Database', 'Collection', 'ObjectId']
+__all__ = ['Connection', 'Database', 'Collection', 'ObjectId', 'WriteConcern']
 
 
+from .write_concern import WriteConcern
 from .connection import Connection, MongoClient
 from .database import Database
 from .collection import Collection

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -518,10 +518,10 @@ class Collection(object):
                         manipulate, safe, _check_keys = True, **kwargs)
             return to_save.get("_id", None)
 
-    def remove(self, spec_or_id = None, search_filter = None, **kwargs):
+    def remove(self, spec_or_id = None, search_filter = None, **write_concern_kwargs):
         """Remove objects matching spec_or_id from the collection."""
-        if kwargs:
-            write_concern = WriteConcern(**kwargs)
+        if write_concern_kwargs:
+            write_concern = WriteConcern(**write_concern_kwargs)
         if search_filter is not None:
             print_deprecation_warning('search_filter', 'spec_or_id')
         if spec_or_id is None:

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from sentinels import NOTHING
 from .filtering import filter_applies, iter_key_candidates
-from . import ObjectId, OperationFailure, DuplicateKeyError
+from . import ObjectId, OperationFailure, DuplicateKeyError, WriteConcern
 from .helpers import basestring, xrange, print_deprecation_warning, hashdict
 
 try:
@@ -520,6 +520,8 @@ class Collection(object):
 
     def remove(self, spec_or_id = None, search_filter = None, **kwargs):
         """Remove objects matching spec_or_id from the collection."""
+        if kwargs:
+            write_concern = WriteConcern(**kwargs)
         if search_filter is not None:
             print_deprecation_warning('search_filter', 'spec_or_id')
         if spec_or_id is None:

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -518,7 +518,7 @@ class Collection(object):
                         manipulate, safe, _check_keys = True, **kwargs)
             return to_save.get("_id", None)
 
-    def remove(self, spec_or_id = None, search_filter = None):
+    def remove(self, spec_or_id = None, search_filter = None, **kwargs):
         """Remove objects matching spec_or_id from the collection."""
         if search_filter is not None:
             print_deprecation_warning('search_filter', 'spec_or_id')

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -318,7 +318,7 @@ class Collection(object):
         # TODO: this looks a little too naive...
         return dict((k, v) for k, v in iteritems(doc) if not k.startswith("$"))
 
-    def find(self, spec = None, fields = None, filter = None, sort = None, timeout = True, limit = 0, snapshot = False, as_class = None, skip = 0, slave_okay=False):
+    def find(self, spec = None, fields = None, filter = None, sort = None, timeout = True, limit = 0, snapshot = False, as_class = None, skip = 0, slave_okay=False, no_cursor_timeout=False):
         if filter is not None:
             print_deprecation_warning('filter', 'spec')
             if spec is None:

--- a/mongomock/write_concern.py
+++ b/mongomock/write_concern.py
@@ -1,0 +1,3 @@
+class WriteConcern(object):
+    def __init__(self, w=None, wtimeout=None, j=None, fsync=None):
+        pass

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -132,6 +132,13 @@ class CollectionAPITest(TestCase):
 
         self.assertEquals(self.db.col.remove({"bla": 1})["n"], 0)
 
+    def test__remove_write_concern(self):
+        self.db.col.remove({"a": 1}, w=None, wtimeout=None, j=None, fsync=None)
+
+    def test__remove_bad_write_concern(self):
+        with self.assertRaises(TypeError):
+            self.db.col.remove({"a": 1}, bad_kwarg=1)
+
     def test__getting_collection_via_getattr(self):
         col1 = self.db.some_collection_here
         col2 = self.db.some_collection_here


### PR DESCRIPTION
Hello!

Adapting those signatures fixed using MongoMock with MongoEngine for me.

I got it working with:

```
def get_connection(alias):
    return mongomock.Connection()

mongoengine.connection.get_connection = get_connection
mongoengine.connect('db')
```