### PR TITLE
Implement get_default_database (Fix #198)

### DIFF
--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -1,5 +1,3 @@
-from .helpers import ObjectId  # noqa
-
 try:
     from pymongo.errors import PyMongoError
 except ImportError:
@@ -30,6 +28,19 @@ except ImportError:
     class InvalidOperation(PyMongoError):
         pass
 
+try:
+    from pymongo.errors import ConfigurationError
+except ImportError:
+    class ConfigurationError(PyMongoError):
+        pass
+
+try:
+    from pymongo.errors import InvalidURI
+except ImportError:
+    class InvalidURI(ConfigurationError):
+        pass
+
+from .helpers import ObjectId  # noqa
 from mongomock.__version__ import __version__
 
 

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -6,6 +6,7 @@ class MongoClient(object):
 
     HOST = 'localhost'
     PORT = 27017
+    DEFAULT_DB = '__DEFAULT__'
     _CONNECTION_ID = itertools.count()
 
     def __init__(self, host=None, port=None, document_class=dict,
@@ -72,6 +73,9 @@ class MongoClient(object):
         if db is None:
             db = self._databases[name] = Database(self, name)
         return db
+
+    def get_default_database(self):
+        return self[self.__class__.DEFAULT_DB]
 
     def alive(self):
         """The original MongoConnection.alive method checks the status of the server.

--- a/tests/connection_string/test/valid-auth.json
+++ b/tests/connection_string/test/valid-auth.json
@@ -1,0 +1,330 @@
+{
+    "tests": [
+        {
+            "auth": {
+                "db": null, 
+                "password": "foo", 
+                "username": "alice"
+            }, 
+            "description": "User info for single IPv4 host without database", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:foo@127.0.0.1", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "test", 
+                "password": "foo", 
+                "username": "alice"
+            }, 
+            "description": "User info for single IPv4 host with database", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:foo@127.0.0.1/test", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "t\u0000est", 
+                "password": "f\u0000oo", 
+                "username": "a\u0000lice"
+            }, 
+            "description": "User info for single IPv4 host with database (escaped null bytes)", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://a%00lice:f%00oo@127.0.0.1/t%00est", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": "bar", 
+                "username": "bob"
+            }, 
+            "description": "User info for single IP literal host without database", 
+            "hosts": [
+                {
+                    "host": "::1", 
+                    "port": 27018, 
+                    "type": "ip_literal"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://bob:bar@[::1]:27018", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "bar", 
+                "username": "bob"
+            }, 
+            "description": "User info for single IP literal host with database", 
+            "hosts": [
+                {
+                    "host": "::1", 
+                    "port": 27018, 
+                    "type": "ip_literal"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://bob:bar@[::1]:27018/admin", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": "baz", 
+                "username": "eve"
+            }, 
+            "description": "User info for single hostname without database", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://eve:baz@example.com", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "db2", 
+                "password": "baz", 
+                "username": "eve"
+            }, 
+            "description": "User info for single hostname with database", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://eve:baz@example.com/db2", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": "secret", 
+                "username": "alice"
+            }, 
+            "description": "User info for multiple hosts without database", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }, 
+                {
+                    "host": "example.com", 
+                    "port": 27018, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:secret@127.0.0.1,example.com:27018", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "secret", 
+                "username": "alice"
+            }, 
+            "description": "User info for multiple hosts with database", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }, 
+                {
+                    "host": "::1", 
+                    "port": 27019, 
+                    "type": "ip_literal"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:secret@example.com,[::1]:27019/admin", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": null, 
+                "username": "alice"
+            }, 
+            "description": "Username without password", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice@127.0.0.1", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": "", 
+                "username": "alice"
+            }, 
+            "description": "Username with empty password", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:@127.0.0.1", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "my=db", 
+                "password": null, 
+                "username": "@l:ce"
+            }, 
+            "description": "Escaped username and database without password", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%40l%3Ace@example.com/my%3Ddb", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin?", 
+                "password": "f:zzb@zz", 
+                "username": "$am"
+            }, 
+            "description": "Escaped user info and database (MONGODB-CR)", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": {
+                "authmechanism": "MONGODB-CR"
+            }, 
+            "uri": "mongodb://%24am:f%3Azzb%40zz@127.0.0.1/admin%3F?authMechanism=MONGODB-CR", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": null, 
+                "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
+            }, 
+            "description": "Escaped username (MONGODB-X509)", 
+            "hosts": [
+                {
+                    "host": "localhost", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "authmechanism": "MONGODB-X509"
+            }, 
+            "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": null, 
+                "password": "secret", 
+                "username": "user@EXAMPLE.COM"
+            }, 
+            "description": "Escaped username (GSSAPI)", 
+            "hosts": [
+                {
+                    "host": "localhost", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "authmechanism": "GSSAPI", 
+                "authmechanismproperties": {
+                    "CANONICALIZE_HOST_NAME": true, 
+                    "SERVICE_NAME": "other"
+                }
+            }, 
+            "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "secret", 
+                "username": "alice"
+            }, 
+            "description": "At-signs in options aren't part of the userinfo", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "replicaset": "my@replicaset"
+            }, 
+            "uri": "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset", 
+            "valid": true, 
+            "warning": false
+        }
+    ]
+}

--- a/tests/connection_string/test/valid-host_identifiers.json
+++ b/tests/connection_string/test/valid-host_identifiers.json
@@ -1,0 +1,154 @@
+{
+    "tests": [
+        {
+            "auth": null, 
+            "description": "Single IPv4 host without port", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://127.0.0.1", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Single IPv4 host with port", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": 27018, 
+                    "type": "ipv4"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://127.0.0.1:27018", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Single IP literal host without port", 
+            "hosts": [
+                {
+                    "host": "::1", 
+                    "port": null, 
+                    "type": "ip_literal"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://[::1]", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Single IP literal host with port", 
+            "hosts": [
+                {
+                    "host": "::1", 
+                    "port": 27019, 
+                    "type": "ip_literal"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://[::1]:27019", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Single hostname without port", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://example.com", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Single hostname with port", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": 27020, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://example.com:27020", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Single hostname (resembling IPv4) without port", 
+            "hosts": [
+                {
+                    "host": "256.0.0.1", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://256.0.0.1", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple hosts (mixed formats)", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": null, 
+                    "type": "ipv4"
+                }, 
+                {
+                    "host": "::1", 
+                    "port": 27018, 
+                    "type": "ip_literal"
+                }, 
+                {
+                    "host": "example.com", 
+                    "port": 27019, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://127.0.0.1,[::1]:27018,example.com:27019", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "UTF-8 hosts", 
+            "hosts": [
+                {
+                    "host": "b\u00fccher.example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }, 
+                {
+                    "host": "uml\u00e4ut.example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://b\u00fccher.example.com,uml\u00e4ut.example.com/", 
+            "valid": true, 
+            "warning": false
+        }
+    ]
+}

--- a/tests/connection_string/test/valid-options.json
+++ b/tests/connection_string/test/valid-options.json
@@ -1,0 +1,42 @@
+{
+    "tests": [
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "secret", 
+                "username": "alice"
+            }, 
+            "description": "Option names are normalized to lowercase", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "authmechanism": "MONGODB-CR"
+            }, 
+            "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Option key and value (escaped null bytes)", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "replicaset": "my\u0000rs"
+            }, 
+            "uri": "mongodb://example.com/?replicaSet=my%00rs", 
+            "valid": true, 
+            "warning": false
+        }
+    ]
+}

--- a/tests/connection_string/test/valid-unix_socket-absolute.json
+++ b/tests/connection_string/test/valid-unix_socket-absolute.json
@@ -1,0 +1,251 @@
+{
+    "tests": [
+        {
+            "auth": null, 
+            "description": "Unix domain socket (absolute path with trailing slash)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket (absolute path without trailing slash)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket (absolute path with spaces in path)", 
+            "hosts": [
+                {
+                    "host": "/tmp/ /mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple Unix domain sockets (absolute paths)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple hosts (absolute path and ipv4)", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": 27017, 
+                    "type": "ipv4"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://127.0.0.1:27017,%2Ftmp%2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple hosts (absolute path and hostname resembling relative path)", 
+            "hosts": [
+                {
+                    "host": "mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "hostname"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://mongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "foo", 
+                "username": "alice"
+            }, 
+            "description": "Unix domain socket with auth database (absolute path)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:foo@%2Ftmp%2Fmongodb-27017.sock/admin", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket with path resembling socket file (absolute path with trailing slash)", 
+            "hosts": [
+                {
+                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket with path resembling socket file (absolute path without trailing slash)", 
+            "hosts": [
+                {
+                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "bar", 
+                "username": "bob"
+            }, 
+            "description": "Unix domain socket with path resembling socket file and auth (absolute path)", 
+            "hosts": [
+                {
+                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://bob:bar@%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/admin", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin.sock", 
+                "password": null, 
+                "username": null
+            }, 
+            "description": "Multiple Unix domain sockets and auth DB resembling a socket (absolute path)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin.shoe", 
+                "password": null, 
+                "username": null
+            }, 
+            "description": "Multiple Unix domain sockets with auth DB resembling a path (absolute path)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin.shoe", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "bar", 
+                "username": "bob"
+            }, 
+            "description": "Multiple Unix domain sockets with auth and query string (absolute path)", 
+            "hosts": [
+                {
+                    "host": "/tmp/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": {
+                "w": 1
+            }, 
+            "uri": "mongodb://bob:bar@%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin?w=1", 
+            "valid": true, 
+            "warning": false
+        }
+    ]
+}

--- a/tests/connection_string/test/valid-unix_socket-relative.json
+++ b/tests/connection_string/test/valid-unix_socket-relative.json
@@ -1,0 +1,271 @@
+{
+    "tests": [
+        {
+            "auth": null, 
+            "description": "Unix domain socket (relative path with trailing slash)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fmongodb-27017.sock/", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket (relative path without trailing slash)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket (relative path with spaces)", 
+            "hosts": [
+                {
+                    "host": "rel/ /mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2F %2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple Unix domain sockets (relative paths)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "rel/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple Unix domain sockets (relative and absolute paths)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "/tmp/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple hosts (relative path and ipv4)", 
+            "hosts": [
+                {
+                    "host": "127.0.0.1", 
+                    "port": 27017, 
+                    "type": "ipv4"
+                }, 
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://127.0.0.1:27017,rel%2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Multiple hosts (relative path and hostname resembling relative path)", 
+            "hosts": [
+                {
+                    "host": "mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "hostname"
+                }, 
+                {
+                    "host": "rel/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://mongodb-27017.sock,rel%2Fmongodb-27018.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "foo", 
+                "username": "alice"
+            }, 
+            "description": "Unix domain socket with auth database (relative path)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://alice:foo@rel%2Fmongodb-27017.sock/admin", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket with path resembling socket file (relative path with trailing slash)", 
+            "hosts": [
+                {
+                    "host": "rel/path.to.sock/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock/", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": null, 
+            "description": "Unix domain socket with path resembling socket file (relative path without trailing slash)", 
+            "hosts": [
+                {
+                    "host": "rel/path.to.sock/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "bar", 
+                "username": "bob"
+            }, 
+            "description": "Unix domain socket with path resembling socket file and auth (relative path)", 
+            "hosts": [
+                {
+                    "host": "rel/path.to.sock/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://bob:bar@rel%2Fpath.to.sock%2Fmongodb-27017.sock/admin", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin.sock", 
+                "password": null, 
+                "username": null
+            }, 
+            "description": "Multiple Unix domain sockets and auth DB resembling a socket (relative path)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "rel/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin.sock", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin.shoe", 
+                "password": null, 
+                "username": null
+            }, 
+            "description": "Multiple Unix domain sockets with auth DB resembling a path (relative path)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "rel/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin.shoe", 
+            "valid": true, 
+            "warning": false
+        }, 
+        {
+            "auth": {
+                "db": "admin", 
+                "password": "bar", 
+                "username": "bob"
+            }, 
+            "description": "Multiple Unix domain sockets with auth and query string (relative path)", 
+            "hosts": [
+                {
+                    "host": "rel/mongodb-27017.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }, 
+                {
+                    "host": "rel/mongodb-27018.sock", 
+                    "port": null, 
+                    "type": "unix"
+                }
+            ], 
+            "options": {
+                "w": 1
+            }, 
+            "uri": "mongodb://bob:bar@rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin?w=1", 
+            "valid": true, 
+            "warning": false
+        }
+    ]
+}

--- a/tests/connection_string/test/valid-warnings.json
+++ b/tests/connection_string/test/valid-warnings.json
@@ -1,0 +1,68 @@
+{
+    "tests": [
+        {
+            "auth": null, 
+            "description": "Unrecognized option keys are ignored", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://example.com/?foo=bar", 
+            "valid": true, 
+            "warning": true
+        }, 
+        {
+            "auth": null, 
+            "description": "Unsupported option values are ignored", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": null, 
+            "uri": "mongodb://example.com/?fsync=ifPossible", 
+            "valid": true, 
+            "warning": true
+        }, 
+        {
+            "auth": null, 
+            "description": "Repeated option keys", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "replicaset": "test"
+            }, 
+            "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test", 
+            "valid": true, 
+            "warning": true
+        }, 
+        {
+            "auth": null, 
+            "description": "Deprecated (or unknown) options are ignored if replacement exists", 
+            "hosts": [
+                {
+                    "host": "example.com", 
+                    "port": null, 
+                    "type": "hostname"
+                }
+            ], 
+            "options": {
+                "wtimeoutms": 10
+            }, 
+            "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10", 
+            "valid": true, 
+            "warning": true
+        }
+    ]
+}

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -1,4 +1,8 @@
+import json
+import os
+
 from mongomock.helpers import hashdict
+from mongomock.helpers import parse_dbase_from_uri
 from mongomock.helpers import print_deprecation_warning
 from unittest import TestCase
 
@@ -25,3 +29,66 @@ class TestDeprecationWarning(TestCase):
     def test__deprecation_warning(self):
         # ensure this doesn't throw an exception
         print_deprecation_warning('aaa', 'bbb')
+
+
+class TestAllUriScenarios(TestCase):
+    pass
+
+
+_URI_SPEC_TEST_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    os.path.join('connection_string', 'test'))
+
+
+def create_uri_spec_tests():
+    """Use json specifications in `_TEST_PATH` to generate uri spec tests.
+
+    This is a simplified version from the PyMongo "test/test_uri_spec.py". It
+    is modified to disregard warnings and only check that valid uri's are valid
+    with the correct database.
+    """
+    def create_uri_spec_test(scenario_def):
+        def run_scenario(self):
+            self.assertTrue(scenario_def['tests'], "tests cannot be empty")
+            for test in scenario_def['tests']:
+                dsc = test['description']
+
+                error = False
+
+                try:
+                    dbase = parse_dbase_from_uri(test['uri'])
+                except Exception as e:
+                    print(e)
+                    error = True
+
+                self.assertEqual(not error, test['valid'],
+                                 "Test failure '%s'" % dsc)
+
+                # Compare auth options.
+                auth = test['auth']
+                if auth is not None:
+                    expected_dbase = auth.pop('db')  # db == database
+                    # Special case for PyMongo's collection parsing
+                    if expected_dbase and '.' in expected_dbase:
+                        expected_dbase, _ = expected_dbase.split('.', 1)
+                    self.assertEqual(expected_dbase, dbase,
+                                     "Expected %s but got %s"
+                                     % (expected_dbase, dbase))
+        return run_scenario
+
+    for dirpath, _, filenames in os.walk(_URI_SPEC_TEST_PATH):
+        dirname = os.path.split(dirpath)
+        dirname = os.path.split(dirname[-2])[-1] + '_' + dirname[-1]
+
+        for filename in filenames:
+            with open(os.path.join(dirpath, filename)) as scenario_stream:
+                scenario_def = json.load(scenario_stream)
+            # Construct test from scenario.
+            new_test = create_uri_spec_test(scenario_def)
+            test_name = 'test_%s_%s' % (
+                dirname, os.path.splitext(filename)[0])
+            new_test.__name__ = test_name
+            setattr(TestAllUriScenarios, new_test.__name__, new_test)
+
+
+create_uri_spec_tests()

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -98,6 +98,14 @@ class DatabaseGettingTest(TestCase):
         a = db.dereference(DBRef("a", "a", db.name))
         self.assertEqual(to_insert, a)
 
+    def test__getting_default_database(self):
+        db = self.client.get_default_database()
+
+        self.assertIsNotNone(db)
+        self.assertIs(db, self.client[mongomock.MongoClient.DEFAULT_DB])
+        self.assertIsInstance(db, Database)
+        self.assertIs(db.client, self.client)
+
 
 @skipIf(not _HAVE_PYMONGO, "pymongo not installed")
 class _CollectionComparisonTest(TestCase):


### PR DESCRIPTION
Add a simple implementation of `MongoClient.get_default_database`. It always returns the same database `__DEFAULT__` specified by the class field `MongoClient.DEFAULT_DB`. 

This would be more accurately implemented by using `pymongo.uri_parser.parse_uri` ([docs](http://api.mongodb.org/python/current/api/pymongo/uri_parser.html)) to parse the default database from the URI if the MongoClient was created with a URI and otherwise throw an error if not.

I did not use this approach because I wanted to get some feedback on the best approach for how to do that since I'm guessing we do not want to add pymongo as a dependency. 

From pymongo:
```
def get_default_database(self):
    if self.__default_database_name is None:
        raise ConfigurationError('No default database defined')

    return self[self.__default_database_name]
```