### PR TITLE
Add basic with_options collection method

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1459,6 +1459,10 @@ class Collection(object):
                             "for a complete list of valid operators." % k)
         return CommandCursor(out_collection)
 
+    def with_options(
+            self, codec_options=None, read_preference=None, write_concern=None, read_concern=None):
+        return self
+
 
 def _resolve_key(key, doc):
     return next(iter(iter_key_candidates(key, doc)), NOTHING)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -735,3 +735,6 @@ class CollectionAPITest(TestCase):
         data_in_db = self.db.collection.find(projection=['a.b.c'])
         self.assertEqual(
             list(data_in_db), [{"_id": 1, "a": {"b": {"c": 2}}}])
+
+    def test__with_options(self):
+        self.db.collection.with_options(read_preference=None)


### PR DESCRIPTION
Some clients might already be using collection#with_options, e.g. [mongoengine relies on mongomock for testing](https://mongoengine-odm.readthedocs.org/guide/mongomock.html) and [uses  with_options](https://github.com/MongoEngine/mongoengine/blob/b32006441847298405f5be7711477a88163ae064/mongoengine/queryset/base.py#L1485-L1488) to [reload a document](https://github.com/MongoEngine/mongoengine/blob/b32006441847298405f5be7711477a88163ae064/mongoengine/document.py#L606), etc.
I'm sure that  `read_preference`, `write_concern`, `read_concern` should be ignored, although I'm not so sure about `codec_options`. But I assume that it's OK to ignore them because there are already some [examples that are using the same approach](https://github.com/vmalloc/mongomock/blob/2616e57ceaa2695c350aa76608686c891a4c7f1e/mongomock/mongo_client.py#L78).
Also, I didn't even clone current instance of collection. Not sure if someone might rely on collection instance to be different from the original one.
