### PR TITLE
Basic support for $currentDate operation

### DIFF
--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime
 import random
 from six import text_type
 import time
@@ -738,3 +739,16 @@ class CollectionAPITest(TestCase):
 
     def test__with_options(self):
         self.db.collection.with_options(read_preference=None)
+
+    def test__update_current_date(self):
+        for type_specification in [True, {'$type': 'date'}]:
+            self.db.collection.update_one(
+                {}, {'$currentDate': {'updated_at': type_specification}}, upsert=True)
+            self.assertIsInstance(
+                self.db.collection.find_one({})['updated_at'], datetime)
+
+    # should be removed once Timestamp supported or implemented
+    def test__current_date_timestamp_is_not_supported_yet(self):
+        with self.assertRaises(NotImplementedError):
+            self.db.collection.update_one(
+                {}, {'$currentDate': {'updated_at': {'$type': 'timestamp'}}}, upsert=True)


### PR DESCRIPTION
Timestamp is not supported so far, hence throwing `NotImplementedError` when [typeSpecification]( https://docs.mongodb.org/manual/reference/operator/update/currentDate/#definition) is exactly `{'$type': 'timestamp'}`.
Not sure if `typeSpecification` should be restricted to `True` or `{'$type': 'date'}` in mongomock. Since I've noticed some weird behavior in mongo, e.g. it allows `$currentDate: {foo: False}` and treats it exatly the same as  `$currentDate: {foo: True}` while prohibiting `$currentDate: {foo: 1}`