### PR TITLE
Issue #211: Expand dotted attributes on upsert

### DIFF
--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -40,6 +40,12 @@ except ImportError:
     class InvalidURI(ConfigurationError):
         pass
 
+try:
+    from pymongo.errors import WriteError
+except ImportError:
+    class WriteError(OperationFailure):
+        pass
+
 from .helpers import ObjectId  # noqa
 from mongomock.__version__ import __version__
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -44,6 +44,7 @@ from mongomock.results import InsertManyResult
 from mongomock.results import InsertOneResult
 from mongomock.results import UpdateResult
 from mongomock.write_concern import WriteConcern
+from mongomock import WriteError
 
 
 def validate_is_mapping(option, value):
@@ -351,6 +352,7 @@ class Collection(object):
                     continue
                 _id = document.get('_id')
                 to_insert = dict(spec, _id=_id) if _id else spec
+                to_insert = self._expand_dots(to_insert)
                 upserted_id = self._insert(self._discard_operators(to_insert))
                 existing_document = self._documents[upserted_id]
                 was_insert = True
@@ -639,6 +641,24 @@ class Collection(object):
             subspec = subspec[subfield]
 
         return subdocument
+
+    def _expand_dots(self, doc):
+        expanded = {}
+        paths = {}
+        for k, v in iteritems(doc):
+            key_parts = k.split('.')
+            sub_doc = v
+            for i in reversed(range(1, len(key_parts))):
+                key = key_parts[i]
+                sub_doc = {key: sub_doc}
+            key = key_parts[0]
+            if key in expanded:
+                raise WriteError("cannot infer query fields to set, "
+                                 "both paths '%s' and '%s' are matched"
+                                 % (k, paths[key]))
+            paths[key] = k
+            expanded[key] = sub_doc
+        return expanded
 
     def _discard_operators(self, doc):
         # TODO(this looks a little too naive...)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -401,6 +401,20 @@ class CollectionAPITest(TestCase):
         self.assertIsNotNone(update_result.upserted_id)
         self.assert_document_stored(update_result.upserted_id, {'a': 1})
 
+    def test__update_one_upsert_dots(self):
+        self.assert_document_count(0)
+        update_result = self.db.collection.update_one(
+            {'a.b': 1}, {'$set': {'c': 2}}, upsert=True)
+        self.assertEqual(update_result.modified_count, 0)
+        self.assertEqual(update_result.matched_count, 0)
+        self.assertIsNotNone(update_result.upserted_id)
+        self.assert_document_stored(update_result.upserted_id, {'a': {'b': 1}, 'c': 2})
+
+    def test__update_one_upsert_invalid_filter(self):
+        with self.assertRaises(mongomock.WriteError):
+            self.db.collection.update_one(
+                {'a.b': 1, 'a': 3}, {'$set': {'c': 2}}, upsert=True)
+
     def test__update_many(self):
         self.db.collection.insert_many([
             {'a': 1, 'c': 2},

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -756,6 +756,11 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             {'a': 1}, {'_id': ObjectId('52d669dcad547f059424f783'), 'a': 1}, upsert=True)
         self.cmp.compare.find()
 
+    def test__update_upsert_with_dots(self):
+        self.cmp.do.update(
+            {'a.b': 1}, {'$set': {'c': 2}}, upsert=True)
+        self.cmp.compare.find()
+
     def test__update_one(self):
         self.cmp.do.insert_many([{'a': 1, 'b': 0},
                                  {'a': 2, 'b': 0}])


### PR DESCRIPTION
Fix for #211

- Expand dotted query attributes before inserting in the case of an upsert
- Raise WriteError on conflict
- Unit tests