### PR TITLE
Fix find_one to use filter as arg

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -909,16 +909,16 @@ class Collection(object):
         return (document for document in list(itervalues(self._documents))
                 if filter_applies(filter, document))
 
-    def find_one(self, spec_or_id=None, *args, **kwargs):
+    def find_one(self, filter=None, *args, **kwargs):
         # Allow calling find_one with a non-dict argument that gets used as
         # the id for the query.
-        if spec_or_id is None:
-            spec_or_id = {}
-        if not isinstance(spec_or_id, collections.Mapping):
-            spec_or_id = {'_id': spec_or_id}
+        if filter is None:
+            filter = {}
+        if not isinstance(filter, collections.Mapping):
+            filter = {'_id': filter}
 
         try:
-            return next(self.find(spec_or_id, *args, **kwargs))
+            return next(self.find(filter, *args, **kwargs))
         except StopIteration:
             return None
 


### PR DESCRIPTION
Hi,

pymongo>3 has the [following signature](https://github.com/mongodb/mongo-python-driver/blob/3.0/pymongo/collection.py#L762) `def find_one(self, filter=None, *args, **kwargs)`

This fix correct the `find_one` signature

Btw it seems the document is not up to date regarding this (see https://jira.mongodb.org/browse/PYTHON-1086)
