### PR TITLE
Cache pip explicitly in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 sudo: true
-cache:
-  directories:
-    - $HOME/.cache/pip
+cache: pip
 env:
   - TOX_ENV=py27-pymongo
   - TOX_ENV=py27-pyexecjs


### PR DESCRIPTION
It's now allowed to specify cache: pip even if you override the install section.