### PR TITLE
add datetime.datetime to diff _SUPPORTED_TYPES

### DIFF
--- a/tests/diff.py
+++ b/tests/diff.py
@@ -1,4 +1,5 @@
 from platform import python_version
+import datetime
 
 
 class _NO_VALUE(object):
@@ -7,7 +8,7 @@ class _NO_VALUE(object):
 NO_VALUE = _NO_VALUE()
 
 _SUPPORTED_TYPES = set([
-    int, float, bool, str
+    int, float, bool, str, datetime.datetime
 ])
 
 dict_type = dict

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -1,5 +1,5 @@
-from platform import python_version
 import datetime
+from platform import python_version
 
 
 class _NO_VALUE(object):


### PR DESCRIPTION
 test__aggregate1 and test__aggregate4 (test__mongomock.MongoClientAggregateTest) fail when I run tests.
I figured out that it is due to the datetime object in data attribute that is not listed in _SUPPORTED_TYPES in diff module.
Since datetime objects can be compared, I think it can be safely added.
If I am wrong, would you know why those tests could fail ?
